### PR TITLE
Added support for custom dialog window type

### DIFF
--- a/packages/react-config/frameDialog/frameDialog.tsx
+++ b/packages/react-config/frameDialog/frameDialog.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { WindowFrame, WindowClientArea, ThemeContextProvider } from "@bond-wm/react";
+import {
+  TitleBar,
+  TitleBarCloseButton,
+  TitleBarIcon,
+  TitleBarText,
+} from "@bond-wm/react-titlebar";
+import { MyTheme } from "../theme";
+
+export default () => {
+  return (
+    <ThemeContextProvider theme={MyTheme}>
+      <WindowFrame>
+        <TitleBar height={15}>
+          <TitleBarIcon />
+          <TitleBarText />
+          <TitleBarCloseButton />
+        </TitleBar>
+        <WindowClientArea />
+      </WindowFrame>
+    </ThemeContextProvider>
+  );
+};

--- a/packages/react-config/frameDialog/index.html
+++ b/packages/react-config/frameDialog/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title></title>
+  </head>
+  <body>
+    <div id="content"></div>
+  </body>
+  <script type="module">
+    import React from "react";
+    import { createRoot } from "react-dom/client";
+    import MyFrame from "./frameDialog.tsx";
+
+    const reactRoot = createRoot(document.getElementById("content"));
+    reactRoot.render(React.createElement(MyFrame));
+  </script>
+</html>

--- a/packages/react-config/package.json
+++ b/packages/react-config/package.json
@@ -6,6 +6,7 @@
     ".": "./index.ts",
     "./desktop/index.html": "./desktop/index.html",
     "./frame/index.html": "./frame/index.html",
+    "./frameDialog/index.html": "./frameDialog/index.html",
     "./package.json": "./package.json"
   },
   "repository": "https://github.com/wnayes/bond-wm",


### PR DESCRIPTION
Sometimes we want to add a different style or decoration for different types of windows, this PR adds initial support for this.
In my example, the window title have a height of 15, in addition to the more obvious customizations.
Maybe this could be the essential change to allow the creation of a start menu.
![image](https://github.com/wnayes/bond-wm/assets/74947997/0902230d-0491-4713-ba28-42863bebb038)
