### PR TITLE
Da startmenu group by

### DIFF
--- a/packages/react-config/desktop/desktop.tsx
+++ b/packages/react-config/desktop/desktop.tsx
@@ -24,7 +24,7 @@ export default () => {
                   size={{ width: 300, height: screen.height / 2 }}
                 >
                   <StartMenu>
-                    <StartMenuApplicationList />
+                    <StartMenuApplicationList groupBy="all" />
                   </StartMenu>
                 </ChildWindow>
               )}

--- a/packages/react-start-menu/StartMenuApplicationList.tsx
+++ b/packages/react-start-menu/StartMenuApplicationList.tsx
@@ -1,11 +1,17 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useDesktopEntries } from "@bond-wm/react";
 import { DesktopEntry } from "@bond-wm/shared";
 import { executeDesktopEntry, makeDesktopEntryIconUrl } from "@bond-wm/shared-renderer";
 import { useStartMenuContext } from "./StartMenuContext";
 import { defaultCategories } from "./categoryMappings";
+import "./StartMenuStyles.css";
 
-export function StartMenuApplicationList() {
+interface IStartMenuApplicationListProps {
+  groupBy?: "categories" | "all";
+}
+
+export function StartMenuApplicationList({ groupBy = "categories" }: IStartMenuApplicationListProps) {
+  const [currentGroupBy, setCurrentGroupBy] = useState(groupBy);
   const smContext = useStartMenuContext();
 
   const onEntryActivated = useCallback(
@@ -16,8 +22,16 @@ export function StartMenuApplicationList() {
     [smContext]
   );
 
+  const toggleGroupBy = () => {
+    setCurrentGroupBy((prevGroupBy) => (prevGroupBy === "categories" ? "all" : "categories"));
+  };
+
   const entries = useDesktopEntries();
   const categorizedEntries = useMemo(() => {
+    if (currentGroupBy === "all") {
+      return { All: Object.values(entries) };
+    }
+
     const categories: Record<string, DesktopEntry[]> = {};
     Object.values(entries).forEach((entry) => {
       entry.categories?.forEach((category) => {
@@ -29,10 +43,15 @@ export function StartMenuApplicationList() {
       });
     });
     return categories;
-  }, [entries]);
+  }, [entries, currentGroupBy]);
 
   return (
     <div className="startMenuAppList">
+      <div className="listHeader">
+        <div className="toggleButton" onClick={toggleGroupBy}>
+          Group by <span>{currentGroupBy === "categories" ? "All" : "Categories"}</span>
+        </div>
+      </div>
       {Object.entries(categorizedEntries).map(([category, entries]) => (
         <div key={category}>
           <h3>{category}</h3>

--- a/packages/react-start-menu/StartMenuApplicationList.tsx
+++ b/packages/react-start-menu/StartMenuApplicationList.tsx
@@ -4,13 +4,16 @@ import { DesktopEntry } from "@bond-wm/shared";
 import { executeDesktopEntry, makeDesktopEntryIconUrl } from "@bond-wm/shared-renderer";
 import { useStartMenuContext } from "./StartMenuContext";
 import { defaultCategories } from "./categoryMappings";
-import "./StartMenuStyles.css";
 
 interface IStartMenuApplicationListProps {
   groupBy?: "categories" | "all";
+  showGroupByToggle?: boolean;
 }
 
-export function StartMenuApplicationList({ groupBy = "categories" }: IStartMenuApplicationListProps) {
+export function StartMenuApplicationList({
+  groupBy = "categories",
+  showGroupByToggle = true,
+}: IStartMenuApplicationListProps) {
   const [currentGroupBy, setCurrentGroupBy] = useState(groupBy);
   const smContext = useStartMenuContext();
 
@@ -47,11 +50,13 @@ export function StartMenuApplicationList({ groupBy = "categories" }: IStartMenuA
 
   return (
     <div className="startMenuAppList">
-      <div className="listHeader">
-        <div className="toggleButton" onClick={toggleGroupBy}>
-          {currentGroupBy === "categories" ? "All" : "Categories"}
+      {showGroupByToggle && (
+        <div className="startMenuAppListHeader">
+          <div className="startMenuAppListGroupByButton" onClick={toggleGroupBy}>
+            {currentGroupBy === "categories" ? "All" : "Categories"}
+          </div>
         </div>
-      </div>
+      )}
       {Object.entries(categorizedEntries).map(([category, entries]) => (
         <div key={category}>
           <h3>{category}</h3>

--- a/packages/react-start-menu/StartMenuApplicationList.tsx
+++ b/packages/react-start-menu/StartMenuApplicationList.tsx
@@ -49,7 +49,7 @@ export function StartMenuApplicationList({ groupBy = "categories" }: IStartMenuA
     <div className="startMenuAppList">
       <div className="listHeader">
         <div className="toggleButton" onClick={toggleGroupBy}>
-          Group by <span>{currentGroupBy === "categories" ? "All" : "Categories"}</span>
+          {currentGroupBy === "categories" ? "All" : "Categories"}
         </div>
       </div>
       {Object.entries(categorizedEntries).map(([category, entries]) => (

--- a/packages/react-start-menu/StartMenuStyles.css
+++ b/packages/react-start-menu/StartMenuStyles.css
@@ -61,12 +61,9 @@
     text-align: center;
     cursor: pointer;
     font-size: 12px;
-  }
-
-.toggleButton span {
     color: var(--start-menu-entry-hover-bg-color);
   }
-  
+ 
 .listHeader {
     display: flex;
     justify-content: flex-end;

--- a/packages/react-start-menu/StartMenuStyles.css
+++ b/packages/react-start-menu/StartMenuStyles.css
@@ -55,7 +55,7 @@
     border-left: 4px solid var(--start-menu-entry-hover-bg-color);
   }
 
-.toggleButton {
+.startMenuAppListGroupByButton {
     border: none;
     padding: 10px;
     text-align: center;
@@ -64,7 +64,7 @@
     color: var(--start-menu-entry-hover-bg-color);
   }
  
-.listHeader {
+.startMenuAppListHeader {
     display: flex;
     justify-content: flex-end;
   }

--- a/packages/react-start-menu/StartMenuStyles.css
+++ b/packages/react-start-menu/StartMenuStyles.css
@@ -54,3 +54,20 @@
     color: var(--start-menu-entry-hover-bg-color);
     border-left: 4px solid var(--start-menu-entry-hover-bg-color);
   }
+
+.toggleButton {
+    border: none;
+    padding: 10px;
+    text-align: center;
+    cursor: pointer;
+    font-size: 12px;
+  }
+
+.toggleButton span {
+    color: var(--start-menu-entry-hover-bg-color);
+  }
+  
+.listHeader {
+    display: flex;
+    justify-content: flex-end;
+  }


### PR DESCRIPTION
### Description of Changes

**Feature: Group Applications by Categories or All**
<p float="left">
  <img src="https://github.com/user-attachments/assets/c671bd7d-b3a2-4cfb-a6ca-1c35eaa20ae3" width="200" />
  <img src="https://github.com/user-attachments/assets/c2e3ba29-9e66-46b4-8050-bcbd11c98ecb" width="200" />
</p>


This pull request adds the option to group applications in the start menu by categories or display them all in a single list. The default view is by categories, and the user can toggle between views using a button.

### Changes:

- **`groupBy` Property:** Added to `StartMenuApplicationList`, with options `"categories"` (default) and `"all"`.
- **`toggleGroupBy` Function:** Implemented to switch between grouping modes.
- **`categorizedEntries` Memo:** Organizes entries based on the selected grouping option.
- **Styles (CSS):** Added a toggle button in the application list header.


### Future Considerations:
- **Preference Persistence:** Add persistence for the grouping preference across sessions.
- **UI Enhancement:** Replace the "Category" and "All" texts with icons for a more intuitive interface.

### Developer Consideration: 🚧
- I believe the toggle button should not be part of the application list itself to allow the developer to implement their own button. If this is the case, please let me know so I can remove it.
