### PR TITLE
fixes the initial position of the start menu before displaying it

### DIFF
--- a/packages/react-config/desktop/desktop.tsx
+++ b/packages/react-config/desktop/desktop.tsx
@@ -20,6 +20,7 @@ export default () => {
               {() => (
                 <ChildWindow
                   alwaysOnTop
+                  autoFocus
                   position={{ x: 0, y: TaskbarHeight }}
                   size={{ width: 300, height: screen.height / 2 }}
                 >

--- a/packages/react/components/ChildWindow.tsx
+++ b/packages/react/components/ChildWindow.tsx
@@ -29,6 +29,8 @@ export const ChildWindow: FC<IChildWindowProps> = ({ alwaysOnTop, children, posi
       "BondWmChildWindow=true",
       `width=${initialProps.size.width}`,
       `height=${initialProps.size.height}`,
+      `left=-10000`,
+      `top=-10000`,
       `alwaysOnTop=${initialProps.alwaysOnTop}`,
     ].join(",");
     const w = window.open("about:blank", "_blank", features);
@@ -38,7 +40,10 @@ export const ChildWindow: FC<IChildWindowProps> = ({ alwaysOnTop, children, posi
 
   const { x, y } = position;
   useLayoutEffect(() => {
-    win?.moveTo(x, y);
+    if (win) {
+      win.moveTo(x, y);
+      win.focus();
+    }
   }, [win, x, y]);
 
   useLayoutEffect(() => {

--- a/packages/react/components/ChildWindow.tsx
+++ b/packages/react/components/ChildWindow.tsx
@@ -8,6 +8,7 @@ import { Stylesheet } from "./Stylesheet";
 
 export interface IChildWindowProps {
   alwaysOnTop?: boolean;
+  autoFocus?: boolean;
   children?: ReactNode;
   position: { x: number; y: number };
   size: ISize;
@@ -16,10 +17,10 @@ export interface IChildWindowProps {
 /**
  * Component that renders a separate floating window.
  */
-export const ChildWindow: FC<IChildWindowProps> = ({ alwaysOnTop, children, position, size }) => {
+export const ChildWindow: FC<IChildWindowProps> = ({ alwaysOnTop, autoFocus, children, position, size }) => {
   const [win, setWin] = useState<Window | null>(null);
 
-  const [initialProps] = useState({ alwaysOnTop, position, size });
+  const [initialProps] = useState({ alwaysOnTop, position, size, autoFocus });
   if (initialProps.alwaysOnTop !== alwaysOnTop) {
     console.error("ChildWindow alwaysOnTop cannot be changed");
   }
@@ -38,11 +39,16 @@ export const ChildWindow: FC<IChildWindowProps> = ({ alwaysOnTop, children, posi
     return () => w?.close();
   }, [initialProps]);
 
+  useLayoutEffect(() => {
+    if (win && initialProps.autoFocus) {
+      win.focus();
+    }
+  }, [win, initialProps.autoFocus]);
+
   const { x, y } = position;
   useLayoutEffect(() => {
     if (win) {
       win.moveTo(x, y);
-      win.focus();
     }
   }, [win, x, y]);
 


### PR DESCRIPTION
When you click the start menu button, the start menu opens in the center of the screen and then moves to its correct position. This change in position is visible to the user, even though it happens quickly.
This PR resolves the issue.